### PR TITLE
test: simplify symbolic tests using new halmos cheatcode

### DIFF
--- a/test/abstract/Guardians/Guardians.symbolic.t.sol
+++ b/test/abstract/Guardians/Guardians.symbolic.t.sol
@@ -27,7 +27,7 @@ contract GuardiansSymTest is SymTest, Test {
         y = svm.createAddress("y");
     }
 
-    function check_Invariants(bytes4 selector, address caller) public {
+    function check_Invariants(address caller) public {
         _initState();
         vm.assume(x != owner);
         vm.assume(x != y);
@@ -37,9 +37,12 @@ contract GuardiansSymTest is SymTest, Test {
         bool oldGuardianX = guarded.guardians(x);
         bool oldGuardianY = guarded.guardians(y);
 
+        bytes memory data = svm.createCalldata("GuardiansExample");
+        bytes4 selector = bytes4(data);
+
         // Execute an arbitrary tx
         vm.prank(caller);
-        (bool success,) = address(guarded).call(_calldataFor(selector));
+        (bool success,) = address(guarded).call(data);
         vm.assume(success); // ignore reverting cases
 
         // Record post-state
@@ -103,12 +106,5 @@ contract GuardiansSymTest is SymTest, Test {
             vm.prank(owner);
             guarded.pause();
         }
-    }
-
-    /**
-     * @dev Generates valid calldata for a given function selector.
-     */
-    function _calldataFor(bytes4 selector) internal returns (bytes memory) {
-        return abi.encodePacked(selector, svm.createBytes(1024, "data"));
     }
 }

--- a/test/abstract/Migration/Migration.symbolic.t.sol
+++ b/test/abstract/Migration/Migration.symbolic.t.sol
@@ -29,16 +29,19 @@ contract MigrationSymTest is SymTest, Test {
         migration = new MigrationExample(gracePeriod, migrator, owner);
     }
 
-    function check_Invariants(bytes4 selector, address caller) public {
+    function check_Invariants(address caller) public {
         _initState();
 
         // Record pre-state
         uint40 oldMigratedAt = migration.migratedAt();
         address oldMigrator = migration.migrator();
 
+        bytes memory data = svm.createCalldata("MigrationExample");
+        bytes4 selector = bytes4(data);
+
         // Execute an arbitrary tx
         vm.prank(caller);
-        (bool success,) = address(migration).call(_calldataFor(selector));
+        (bool success,) = address(migration).call(data);
         vm.assume(success); // ignore reverting cases
 
         // Record post-state
@@ -107,12 +110,5 @@ contract MigrationSymTest is SymTest, Test {
             vm.prank(migration.migrator());
             migration.migrate();
         }
-    }
-
-    /**
-     * @dev Generates valid calldata for a given function selector.
-     */
-    function _calldataFor(bytes4 selector) internal returns (bytes memory) {
-        return abi.encodePacked(selector, svm.createBytes(1024, "data"));
     }
 }


### PR DESCRIPTION
[this is a temporary pr to be upstreamed after halmos v2 is released.]

this pr improves symbolic tests using new halmos cheatcode `createCalldata()`.

previously, symbolic tests required custom calldata generators to handle dynamic size arrays and bytes. the new `createCalldata()` cheatcode now seamlessly supports such dynamically-sized parameters by considering all combinations of size candidates. these can be specified using additional flags `--array-lengths` and `--default-bytes-lengths` (see `halmos -h` for more details.)

with this new cheatcode, the symbolic tests are now much simpler to understand and maintain, while also accounting for more combinations of dynamic parameter sizes.